### PR TITLE
Add "default values" functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.1.0
+
+- **New feature**: default values.  Allows you to specify a default value like
+  so:
+```
+class User
+  attribute :name, :string, default: 'Michelle'
+end
+
+User.new.name
+# => 'Michelle'
+```
+
 ## 2.0.0
 
 - **Breaking change**: Rename to `ModelAttribute` (no trailing 's') to avoid name

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ class User
     events += new_event
   end
 end
-```
 
 # Supporting default attributes
 
@@ -175,14 +174,23 @@ class UserWithDefaults
   attribute :name, :string, default: 'Charlie'
 end
 
-user = UserWithDefaults.new
+UserWithDefaults.attribute_defaults # => {:name=>"Charlie"}
 
-user.attributes
-# => {:name => 'Charlie', ...}
+user = UserWithDefaults.new
+user.name # => "Charlie"
+user.read_attribute(:name) # => "Charlie"
+user.attributes # => {:name=>"Charlie"}
+# attributes_for_json omits defaults to keep the JSON compact
+user.attributes_for_json # => {}
+# you can add them back in if you need them
+user.attributes_for_json.merge(user.class.attribute_defaults) # => {:name=>"Charlie"}
+# A default isn't a change
+user.changes # => {}
+user.changes_for_json # => {}
 
 user.name = 'Bob'
-user.attributes
-# => {:name => 'Bob', ...}
+user.attributes # => {:name=>"Bob"}
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Simple attributes for a non-ActiveRecord model.
  - Type casting and checking.
  - Dirty tracking.
  - List attribute names and values.
+ - Default values for attributes
  - Handles integers, booleans, strings and times - a set of types that are very
    easy to persist to and parse from JSON.
  - Supports efficient serialization of attributes to JSON.
@@ -165,6 +166,23 @@ class User
   end
 end
 ```
+
+# Supporting default attributes
+
+class UserWithDefaults
+  extend ModelAttribute
+
+  attribute :name, :string, default: 'Charlie'
+end
+
+user = UserWithDefaults.new
+
+user.attributes
+# => {:name => 'Charlie', ...}
+
+user.name = 'Bob'
+user.attributes
+# => {:name => 'Bob', ...}
 
 ## Installation
 

--- a/spec/model_attributes_spec.rb
+++ b/spec/model_attributes_spec.rb
@@ -22,6 +22,14 @@ class UserWithoutId
   end
 end
 
+class UserWithDefaults
+  extend ModelAttribute
+
+  attribute :name,            :string,  default: 'Charlie'
+  attribute :show_full_name,  :boolean, default: true
+  attribute :initial_deposit, :integer, default: 100
+end
+
 RSpec.describe "a class using ModelAttribute" do
   describe "class methods" do
     describe ".attribute" do
@@ -296,6 +304,70 @@ RSpec.describe "a class using ModelAttribute" do
       it "does not provide a profile? method" do
         expect(user).to_not respond_to(:profile?)
         expect { user.profile? }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe 'setting defaults' do
+      let(:user) { UserWithDefaults.new }
+
+      context 'without changing defaults' do
+        it 'should return true for #show_full_name' do
+          expect(user.show_full_name).to eq(true)
+        end
+
+        it 'should return 100 for #initial_deposit' do
+          expect(user.initial_deposit).to eq(100)
+        end
+
+        it 'should return "Charlie" for #name' do
+          expect(user.name).to eq('Charlie')
+        end
+
+        it 'should return defaults in attributes hash' do
+          attrs = user.attributes
+          expect(attrs[:show_full_name]).to  eq(true)
+          expect(attrs[:initial_deposit]).to eq(100)
+          expect(attrs[:name]).to            eq('Charlie')
+        end
+
+        it 'should not return attributes with default values set in attributes_for_json' do
+          json_attrs = user.attributes_for_json
+          expect(json_attrs.key?('show_full_name')).to  eq(false)
+          expect(json_attrs.key?('initial_deposit')).to eq(false)
+          expect(json_attrs.key?('name')).to            eq(false)
+        end
+      end
+
+      context 'when overriding defaults' do
+        before :each do
+          user.show_full_name  = false
+          user.initial_deposit = 200
+          user.name            = 'Michael'
+        end
+
+        it 'should override #show_full_name' do
+          expect(user.show_full_name).to eq(false)
+        end
+
+        it 'should override #initial_deposit' do
+          expect(user.initial_deposit).to eq(200)
+        end
+
+        it 'should override #name' do
+          expect(user.name).to eq('Michael')
+        end
+
+        it 'should return modified values in attributes hash' do
+          attrs = user.attributes
+          expect(attrs[:show_full_name]).to  eq(false)
+          expect(attrs[:initial_deposit]).to eq(200)
+        end
+
+        it 'should return modified attributes in attributes_for_json' do
+          json_attrs = user.attributes_for_json
+          expect(json_attrs['show_full_name']).to  eq(false)
+          expect(json_attrs['initial_deposit']).to eq(200)
+        end
       end
     end
 


### PR DESCRIPTION
Allows you specify a default value, like so:

```ruby
class User
  attribute :name, :string, default: 'Michelle'
end

User.new.name
# => 'Michelle'
```