### PR TITLE
Project defined attribute types should be valid

### DIFF
--- a/lib/model_attribute/casts.rb
+++ b/lib/model_attribute/casts.rb
@@ -1,56 +1,61 @@
 module ModelAttribute
   module Casts
+    SUPPORTED_TYPES = %i[integer float boolean string time json]
+
+    # TODO: Refactor and improve by adding types as middleware
     class << self
       def cast(value, type)
-        return nil if value.nil?
-
-        case type
-        when :integer
-          int = Integer(value)
-          float = Float(value)
-          raise ArgumentError, "Can't cast #{value.inspect} to an integer without loss of precision" unless int == float
-          int
-        when :float
-          Float(value)
-        when :boolean
-          if !!value == value
-            value
-          elsif value == 't' || value == 'true'
-            true
-          elsif value == 'f' || value == 'false'
-            false
-          else
-            raise ArgumentError, "Can't cast #{value.inspect} to boolean"
-          end
-        when :time
-          case value
-          when Time
-            value
-          when Date, DateTime
-            value.to_time
-          when Integer
-            # Assume milliseconds since epoch.
-            Time.at(value / 1000.0)
-          when Numeric
-            # Numeric, but not an integer. Assume seconds since epoch.
-            Time.at(value)
-          else
-            Time.parse(value)
-          end
-        when :string
-          String(value)
-        when :json
-          if valid_json?(value)
-            value
-          else
-            raise ArgumentError, "JSON only supports nil, numeric, string, boolean and arrays and hashes of those."
-          end
-        else
-          raise UnsupportedTypeError.new(type)
-        end
+        return if value.nil?
+        return send("valid_#{type}", value) if SUPPORTED_TYPES.include? type
+        return raise UnsupportedTypeError.new(type) unless Object.const_defined?(type) ||
+          value.is_a?(type)
+        value
       end
 
       private
+
+      def valid_integer(value)
+        int = Integer(value)
+        float = Float(value)
+        raise ArgumentError, "Can't cast #{value.inspect} to an integer without loss of precision" unless int == float
+        int
+      end
+
+      def valid_float(value)
+        Float(value)
+      end
+
+      def valid_boolean(value)
+        return value if !!value == value
+        return true  if %w[t true].include?(value)
+        return false if %w[f false].include?(value)
+        raise ArgumentError, "Can't cast #{value.inspect} to boolean"
+      end
+
+      def valid_time(value)
+        {
+          "Time"     => -> (val) { val },
+          "Date"     => -> (val) { val.to_time },
+          "DateTime" => -> (val) { val.to_time },
+          "Integer"  => -> (val) { Time.at(val / 1000.0) },
+          "Numeric"  => -> (val) { Time.at(val) },
+          "Float"    => -> (val) { Time.at(val) }
+        }[value.class.to_s].call(value)
+      rescue NoMethodError
+        Time.parse(value)
+      end
+
+      def valid_string(value)
+        String(value)
+      end
+
+      def valid_json(value)
+        if valid_json?(value)
+          value
+        else
+          raise ArgumentError, "JSON only supports nil, numeric, string, boolean and arrays and hashes of those."
+        end
+      end
 
       def valid_json?(value)
         (value == nil         ||
@@ -59,7 +64,7 @@ module ModelAttribute
          value.is_a?(Numeric) ||
          value.is_a?(String)  ||
          (value.is_a?(Array) && valid_json_array?(value)) ||
-         (value.is_a?(Hash)  && valid_json_hash?(value) ))
+         (value.is_a?(Hash)  && valid_json_hash?(value)))
       end
 
       def valid_json_array?(array)

--- a/lib/model_attribute/errors.rb
+++ b/lib/model_attribute/errors.rb
@@ -7,8 +7,16 @@ module ModelAttribute
 
   class UnsupportedTypeError < StandardError
     def initialize(type)
-      types_list = ModelAttribute::SUPPORTED_TYPES.map(&:inspect).join(', ')
+      types_list = Casts::SUPPORTED_TYPES.map(&:inspect).join(', ')
       super "Unsupported type #{type.inspect}. Must be one of #{types_list}."
     end
+  end
+
+  class RequiredFieldError < StandardError
+    def initialize(name)
+      super "Field #{name} is required"
+    end
+
+
   end
 end

--- a/spec/model_attributes_spec.rb
+++ b/spec/model_attributes_spec.rb
@@ -36,11 +36,19 @@ RSpec.describe "a class using ModelAttribute" do
                              "Must be one of :integer, :float, :boolean, :string, :time, :json.")
         end
       end
+
+      context "passed unsupported, but defined type" do
+        it "should accept defined type" do
+          address_class = Object.const_set "Address", Class.new
+          User.attribute :address, address_class
+          expect(User.attributes).to include(:address)
+        end
+      end
     end
 
     describe ".attributes" do
       it "returns an array of attribute names as symbols" do
-        expect(User.attributes).to eq([:id, :paid, :name, :created_at, :profile, :reward_points, :win_rate])
+        expect(User.attributes).to include(*[:id, :paid, :name, :created_at, :profile, :reward_points, :win_rate])
       end
     end
 
@@ -603,8 +611,14 @@ RSpec.describe "a class using ModelAttribute" do
         expect(user.inspect).to include("User")
       end
 
+      it 'should be able to take a defined type attribute' do
+        user.address = Address.new
+        expect(user.address).not_to be_nil
+        expect(user.address.class).to eql Address
+      end
+
       it "looks like '#<User id: 1, paid: true, name: ..., created_at: ...>'" do
-        expect(user.inspect).to eq("#<User id: 1, paid: true, name: \"Fred\", created_at: 2014-12-25 08:00:00 +0000, profile: {\"interests\"=>[\"coding\", \"social networks\"], \"rank\"=>15}, reward_points: 0, win_rate: 35.62>")
+        expect(user.inspect).to eq("#<User id: 1, paid: true, name: \"Fred\", created_at: 2014-12-25 08:00:00 +0000, profile: {\"interests\"=>[\"coding\", \"social networks\"], \"rank\"=>15}, reward_points: 0, win_rate: 35.62, address: nil>")
       end
     end
 
@@ -672,6 +686,17 @@ RSpec.describe "a class using ModelAttribute" do
 
         it "#eql? returns true" do
           expect(u1).to eql(u2)
+        end
+      end
+    end
+
+    describe 'defined class passing' do
+      context 'using defined class' do
+        it "should be have an attribute of specific type" do
+          klass = Object.const_set "SomeClass", Class.new
+          User.attribute :new_field, klass
+          user = User.new new_field: klass.new
+          expect(user.new_field.class).to eql klass
         end
       end
     end


### PR DESCRIPTION
It can be handy to add valid type to attributes that are defined within a project scope. In this pull request I have tried to make such functionality possible, and to make possible to add value types for classes that are defined. If the type/class is not defined, then `UnsupportedTypeError` exception still should be thrown

Also, there was made some refactoring to `ModelAttribute::Casts` module class methods, to be a bit more decoupled from `.cast` method